### PR TITLE
Generate sensors for BabyBuddy timers

### DIFF
--- a/custom_components/babybuddy/const.py
+++ b/custom_components/babybuddy/const.py
@@ -130,7 +130,7 @@ SENSOR_TYPES: tuple[BabyBuddyEntityDescription, ...] = (
     ),
     BabyBuddyEntityDescription(
         key=ATTR_TIMERS,
-        state_key=ATTR_ACTIVE,
+        state_key=ATTR_START,
         device_class=DEVICE_CLASS_TIMESTAMP,
         icon="mdi:timer-sand",
     ),

--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -136,8 +136,6 @@ def update_items(
                 tracked[child[ATTR_ID]] = BabyBuddyChildSensor(coordinator, child)
                 new_entities.append(tracked[child[ATTR_ID]])
             for description in SENSOR_TYPES:
-                if description.key == ATTR_TIMERS:
-                    continue
                 if (
                     coordinator.data[1][child[ATTR_ID]].get(description.key)
                     and f"{child[ATTR_ID]}_{description.key}" not in tracked


### PR DESCRIPTION
This PR would address #37. I've tested the change out in a local HA container and verified that it seems to do what I intended. Let me know if there is further validation you'd like to see, or if there was a concrete reason to not expose the last timer as a sensor, as is done with feedings, changes & tummy time.