### PR TITLE
Fix the descriptions of tummy time service parameters

### DIFF
--- a/custom_components/babybuddy/services.yaml
+++ b/custom_components/babybuddy/services.yaml
@@ -146,13 +146,13 @@ add_tummy_time:
       selector:
         boolean:
     start:
-      name: Sleep start time
-      description: Sleep start time
+      name: Tummy Time start time
+      description: Tummy Time start time
       selector:
         time:
     end:
-      name: Sleep end time
-      description: Sleep end time
+      name: Tummy Time end time
+      description: Tummy Time end time
       selector:
         time:
     milestone:


### PR DESCRIPTION
While working on the timer sensors, I noticed that the parameter descriptions for the Tummy Time service contains some copy-paste errors