### PR TITLE
Expired timers are no longer returned by the API

### DIFF
--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -154,13 +154,13 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return entity state."""
-        is_on = False
         if self.child[ATTR_ID] in self.coordinator.data[1]:
             timer_data = self.coordinator.data[1][self.child[ATTR_ID]][ATTR_TIMERS]
-            if ATTR_ACTIVE in timer_data:
-                return timer_data.get(ATTR_ACTIVE, False)
-            else:
-                return len(timer_data) > 0
+            # In Babybuddy 2.0 'active' is not in the JSON response, so return
+            # True if any timers are returned, as only active timers are
+            # returned.
+            return timer_data.get(ATTR_ACTIVE, len(timer_data) > 0)
+        return False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import BabyBuddyCoordinator
 from .client import get_datetime_from_time
 from .const import (
+    ATTR_ACTIVE,
     ATTR_AMOUNT,
     ATTR_CHILD,
     ATTR_END,
@@ -155,8 +156,11 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         """Return entity state."""
         is_on = False
         if self.child[ATTR_ID] in self.coordinator.data[1]:
-            is_on = len(self.coordinator.data[1][self.child[ATTR_ID]][ATTR_TIMERS]) > 0
-        return is_on
+            timer_data = self.coordinator.data[1][self.child[ATTR_ID]][ATTR_TIMERS]
+            if ATTR_ACTIVE in timer_data:
+                return timer_data.get(ATTR_ACTIVE, False)
+            else:
+                return len(timer_data) > 0
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import BabyBuddyCoordinator
 from .client import get_datetime_from_time
 from .const import (
-    ATTR_ACTIVE,
     ATTR_AMOUNT,
     ATTR_CHILD,
     ATTR_END,
@@ -156,9 +155,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         """Return entity state."""
         is_on = False
         if self.child[ATTR_ID] in self.coordinator.data[1]:
-            is_on = self.coordinator.data[1][self.child[ATTR_ID]][ATTR_TIMERS].get(
-                ATTR_ACTIVE, False
-            )
+            is_on = len(self.coordinator.data[1][self.child[ATTR_ID]][ATTR_TIMERS]) > 0
         return is_on
 
     @property


### PR DESCRIPTION
This seems to fix #108 for me

The related change in babybuddy is: https://github.com/babybuddy/babybuddy/commit/7b7f17fde6cc6c45a36752cbf1b2752fe396476d

What's the best way to handle supporting both <2 and 2 at the same time?