### PR TITLE
Fix iot_class in manifest.json

### DIFF
--- a/custom_components/babybuddy/manifest.json
+++ b/custom_components/babybuddy/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://github.com/jcgoette/baby_buddy_homeassistant",
   "integration_type": "service",
-  "iot_class": "cloud_polling",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jcgoette/baby_buddy_homeassistant/issues",
   "requirements": [],
   "version": "v0.0.0"


### PR DESCRIPTION
Fix to use `local_polling` instead of `cloud_polling`. See the docs for `iot_class`: https://developers.home-assistant.io/docs/creating_integration_manifest/#iot-class