### PR TITLE
Remove likely unnecessary default_name, fixes broken 2023.9

### DIFF
--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -204,6 +204,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
         self._attr_device_info = {
             "configuration_url": f"{coordinator.config_entry.data[CONF_HOST]}:{coordinator.config_entry.data[CONF_PORT]}{coordinator.config_entry.data[CONF_PATH]}/children/{child[ATTR_SLUG]}/dashboard/",
             "identifiers": {(DOMAIN, child[ATTR_ID])},
+            "name": f"{child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
         }
 
     async def async_add_bmi(

--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -203,7 +203,6 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
         self.child = child
         self._attr_device_info = {
             "configuration_url": f"{coordinator.config_entry.data[CONF_HOST]}:{coordinator.config_entry.data[CONF_PORT]}{coordinator.config_entry.data[CONF_PATH]}/children/{child[ATTR_SLUG]}/dashboard/",
-            "default_name": f"Baby {child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
             "identifiers": {(DOMAIN, child[ATTR_ID])},
         }
 

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -148,7 +148,6 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_icon = "mdi:timer-sand"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, child[ATTR_ID])},
-            "default_name": f"{child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
         }
 
     @property

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -148,6 +148,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_icon = "mdi:timer-sand"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, child[ATTR_ID])},
+            "name": f"{child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
         }
 
     @property


### PR DESCRIPTION
Closes #119.

Could add child slug (Baby Buddy API unique identifier) in case you want more unique identifiers.