### PR TITLE
Remove default_name from timer switch and baby sensor

### DIFF
--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -203,7 +203,6 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
         self.child = child
         self._attr_device_info = {
             "configuration_url": f"{coordinator.config_entry.data[CONF_HOST]}:{coordinator.config_entry.data[CONF_PORT]}{coordinator.config_entry.data[CONF_PATH]}/children/{child[ATTR_SLUG]}/dashboard/",
-            "default_name": f"Baby {child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
             "identifiers": {(DOMAIN, child[ATTR_ID])},
         }
 

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -148,7 +148,6 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_icon = "mdi:timer-sand"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, child[ATTR_ID])},
-            "default_name": f"{child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}",
         }
 
     @property


### PR DESCRIPTION
Based on information provided in #131. 

Necessary for entities to be grouped with the device in HA 2023.8 and to work at all in 2023.9. 