### PR TITLE
Clarify how to use the DELETE_LAST_ENTRY service

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,14 @@ This service adds a weight entry for your child.
 
 ### SERVICE DELETE_LAST_ENTRY
 
-This service will delete the last entry for specified child.
+This service will delete the last entry for the specified sensor (last weight, last feeding, etc.).
 
-| Service data attribute | Optional | Description                                              |
-| ---------------------- | :------: | -------------------------------------------------------- |
-| entity_id              |    no    | entity_id for the child who's last entry will be deleted |
+> [!CAUTION]
+> Calling this service on a device, which represents a child, in Home Assistant will call the delete service once for *every* sensor on that child.
+
+| Service data attribute | Optional | Description                                                    |
+| ---------------------- | :------: | -------------------------------------------------------------- |
+| entity_id              |    no    | entity_id for the sensor that will have its last entry deleted |
 
 ### SERVICE START_TIMER
 


### PR DESCRIPTION
The current readme says that the DELETE_LAST_ENTRY service should be called on the entity_id of a _child_, but children are devices whereas sensors are entities. Calling DELETE_LAST_ENTRY on a child (device) in Home Assistant does work, but Home Assistant just calls the service for every entity that belongs to that child (device), resulting in the last entry in every sensor getting deleted. That is likely to never be the user's intended behavior.

This update clarifies that the service should be called on a sensor, not a child, and adds a caution to not do what I did and call it on a child.