### PR TITLE
Change feeding sensor to timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # C extensions
 *.so
 
+.idea/*
+
 # Distribution / packaging
 .Python
 build/

--- a/custom_components/babybuddy/__init__.py
+++ b/custom_components/babybuddy/__init__.py
@@ -7,9 +7,10 @@ from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
 
-from aiohttp.client_exceptions import ClientError, ClientResponseError
+import homeassistant.helpers.device_registry as dr
+import homeassistant.util.dt as dt_util
 import voluptuous as vol
-
+from aiohttp.client_exceptions import ClientError, ClientResponseError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ID,
@@ -23,13 +24,10 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-import homeassistant.util.dt as dt_util
 
 from .client import BabyBuddyClient
 from .const import (
-    _LOGGER,
     ATTR_ACTION_ADD_CHILD,
     ATTR_BIRTH_DATE,
     ATTR_CHILDREN,
@@ -41,6 +39,7 @@ from .const import (
     DEFAULT_PATH,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    LOGGER,
     PLATFORMS,
     SENSOR_TYPES,
 )
@@ -86,7 +85,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Handle migration of config entries."""
 
-    _LOGGER.debug(f"Migrating from ConfigFlow version {config_entry.version}.")
+    LOGGER.debug(f"Migrating from ConfigFlow version {config_entry.version}.")
 
     if config_entry.version == 1:
         new = {**config_entry.data}
@@ -96,7 +95,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             config_entry, version=CONFIG_FLOW_VERSION, data=new
         )
 
-    _LOGGER.info(
+    LOGGER.info(
         f"Migration to ConfigFlow version {config_entry.version} successful.",
     )
 
@@ -108,10 +107,10 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the BabyBuddyData object."""
-        _LOGGER.debug("Initializing BabyBuddyCoordinator")
+        LOGGER.debug("Initializing BabyBuddyCoordinator")
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             name=DOMAIN,
             update_method=self.async_update,
             update_interval=timedelta(
@@ -214,12 +213,12 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
                         endpoint.key, f"?child={child[ATTR_ID]}&limit=1"
                     )
                 except ClientResponseError as error:
-                    _LOGGER.debug(
+                    LOGGER.debug(
                         f"No {endpoint} found for {child[ATTR_FIRST_NAME]} {child[ATTR_LAST_NAME]}. Skipping. error: {error}.)"
                     )
                     continue
                 except (AsyncIOTimeoutError, ClientError) as error:
-                    _LOGGER.error(error)
+                    LOGGER.error(error)
                     continue
                 data: list[dict[str, str]] = endpoint_data[ATTR_RESULTS]
                 child_data[child[ATTR_ID]][endpoint.key] = data[0] if data else {}

--- a/custom_components/babybuddy/__init__.py
+++ b/custom_components/babybuddy/__init__.py
@@ -208,7 +208,7 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
         for child in children_list[ATTR_RESULTS]:
             child_data.setdefault(child[ATTR_ID], {})
             for endpoint in SENSOR_TYPES:
-                endpoint_data: dict = {}
+                endpoint_data: dict[str, Any] = {}
                 try:
                     endpoint_data = await self.client.async_get(
                         endpoint.key, f"?child={child[ATTR_ID]}&limit=1"

--- a/custom_components/babybuddy/config_flow.py
+++ b/custom_components/babybuddy/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_API_KEY,
@@ -162,7 +161,7 @@ class BabyBuddyOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        options = {
+        options: dict[vol.Optional, Any] = {
             vol.Optional(
                 TEMPERATURE,
                 default=self.config_entry.options.get(TEMPERATURE, None),

--- a/custom_components/babybuddy/const.py
+++ b/custom_components/babybuddy/const.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
 from typing import Final
 
+import homeassistant.util.dt as dt_util
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,9 +16,8 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.const import ATTR_TIME, UnitOfTime
-import homeassistant.util.dt as dt_util
 
-_LOGGER = logging.getLogger(__package__)
+LOGGER = logging.getLogger(__package__)
 
 DOMAIN: Final[str] = "babybuddy"
 

--- a/custom_components/babybuddy/const.py
+++ b/custom_components/babybuddy/const.py
@@ -10,10 +10,9 @@ from typing import Final
 import homeassistant.util.dt as dt_util
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import (
-    SensorDeviceClass,
     SensorEntityDescription,
-    SensorStateClass,
 )
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.const import ATTR_TIME, UnitOfTime
 

--- a/custom_components/babybuddy/const.py
+++ b/custom_components/babybuddy/const.py
@@ -139,10 +139,10 @@ SENSOR_TYPES: tuple[BabyBuddyEntityDescription, ...] = (
         state_key=ATTR_TIME,
     ),
     BabyBuddyEntityDescription(
+        device_class=SensorDeviceClass.TIMESTAMP,
         icon=ATTR_ICON_BABY_BOTTLE,
         key=ATTR_FEEDINGS,
-        state_class=SensorStateClass.MEASUREMENT,
-        state_key=ATTR_AMOUNT,
+        state_key=ATTR_START,
     ),
     BabyBuddyEntityDescription(
         icon=ATTR_ICON_HEAD,

--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -70,7 +70,7 @@ from .const import (
 )
 from .errors import ValidationError
 
-COMMON_FIELDS = {
+COMMON_FIELDS: dict[vol.Optional, Any] = {
     vol.Optional(ATTR_NOTES): cv.string,
     vol.Optional(ATTR_TAGS): vol.All(cv.ensure_list, [str]),
 }

--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import date, datetime, time
 from typing import Any
 
+import homeassistant.util.dt as dt_util
 import voluptuous as vol
-
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -20,16 +20,15 @@ from homeassistant.const import (
     CONF_PORT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-import homeassistant.util.dt as dt_util
 
 from . import BabyBuddyCoordinator
 from .client import get_datetime_from_time
 from .const import (
-    _LOGGER,
     ATTR_ACTION_ADD_BMI,
     ATTR_ACTION_ADD_DIAPER_CHANGE,
     ATTR_ACTION_ADD_HEAD_CIRCUMFERENCE,
@@ -65,6 +64,7 @@ from .const import (
     DIAPER_TYPES,
     DOMAIN,
     ERROR_CHILD_SENSOR_SELECT,
+    LOGGER,
     SENSOR_TYPES,
     BabyBuddyEntityDescription,
 )
@@ -221,7 +221,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add BMI entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -249,7 +249,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add diaper change entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -259,7 +259,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
                 date_time = get_datetime_from_time(time)
                 data[ATTR_TIME] = date_time
             except ValidationError as error:
-                _LOGGER.error(error)
+                LOGGER.error(error)
                 return
         if type:
             data[ATTR_WET] = type == "Wet and Solid" or type.lower() == ATTR_WET
@@ -286,7 +286,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add head circumference entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -314,7 +314,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add height entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -339,7 +339,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add note entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {ATTR_CHILD: self.child[ATTR_ID], ATTR_NOTE: note}
         if time:
@@ -347,7 +347,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
                 date_time = get_datetime_from_time(time)
                 data[ATTR_TIME] = date_time
             except ValidationError as error:
-                _LOGGER.error(error)
+                LOGGER.error(error)
                 return
         if tags:
             data[ATTR_TAGS] = tags
@@ -365,7 +365,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add a temperature entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -376,7 +376,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
                 date_time = get_datetime_from_time(time)
                 data[ATTR_TIME] = date_time
             except ValidationError as error:
-                _LOGGER.error(error)
+                LOGGER.error(error)
                 return
         if notes:
             data[ATTR_NOTES] = notes
@@ -396,7 +396,7 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Add weight entry."""
         if not isinstance(self, BabyBuddyChildSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
         data = {
             ATTR_CHILD: self.child[ATTR_ID],
@@ -416,11 +416,11 @@ class BabyBuddySensor(CoordinatorEntity, SensorEntity):
     async def async_delete_last_entry(self) -> None:
         """Delete last data entry."""
         if not isinstance(self, BabyBuddyChildDataSensor):
-            _LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
+            LOGGER.debug(ERROR_CHILD_SENSOR_SELECT)
             return
 
         if self.extra_state_attributes.get(ATTR_ID) is None:
-            _LOGGER.error(f"{self.entity_description.key} entry is not available.")
+            LOGGER.error(f"{self.entity_description.key} entry is not available.")
             return
         await self.coordinator.client.async_delete(
             self.entity_description.key, self.extra_state_attributes[ATTR_ID]

--- a/custom_components/babybuddy/sensor.py
+++ b/custom_components/babybuddy/sensor.py
@@ -7,7 +7,8 @@ from typing import Any
 
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DATE,

--- a/custom_components/babybuddy/switch.py
+++ b/custom_components/babybuddy/switch.py
@@ -5,21 +5,20 @@ from __future__ import annotations
 from datetime import datetime, time
 from typing import Any
 
+import homeassistant.util.dt as dt_util
 import voluptuous as vol
-
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ID, ATTR_NAME, CONF_API_KEY
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-import homeassistant.util.dt as dt_util
 
 from . import BabyBuddyCoordinator
 from .client import get_datetime_from_time
 from .const import (
-    _LOGGER,
     ATTR_ACTION_ADD_FEEDING,
     ATTR_ACTION_ADD_PUMPING,
     ATTR_ACTION_ADD_SLEEP,
@@ -47,10 +46,11 @@ from .const import (
     DOMAIN,
     FEEDING_METHODS,
     FEEDING_TYPES,
+    LOGGER,
 )
 from .errors import ValidationError
 
-COMMON_FIELDS = {
+COMMON_FIELDS: dict[vol.Exclusive | vol.Optional, Any] = {
     vol.Exclusive(ATTR_TIMER, group_of_exclusion="timer_or_start"): cv.boolean,
     vol.Exclusive(ATTR_START, group_of_exclusion="timer_or_start"): vol.Any(
         cv.datetime, cv.time
@@ -208,7 +208,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         try:
             data[ATTR_START] = get_datetime_from_time(start or dt_util.now())
         except ValidationError as error:
-            _LOGGER.error(error)
+            LOGGER.error(error)
             return
         if name:
             data[ATTR_NAME] = name
@@ -231,7 +231,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         try:
             data = self.set_common_fields(timer, start, end, tags)
         except ValidationError as error:
-            _LOGGER.error(error)
+            LOGGER.error(error)
             return
 
         data.update(
@@ -262,7 +262,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         try:
             data = self.set_common_fields(timer, start, end, tags)
         except ValidationError as error:
-            _LOGGER.error(error)
+            LOGGER.error(error)
             return
 
         data[ATTR_AMOUNT] = amount
@@ -286,7 +286,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         try:
             data = self.set_common_fields(timer, start, end, tags)
         except ValidationError as error:
-            _LOGGER.error(error)
+            LOGGER.error(error)
             return
 
         if nap is not None:
@@ -309,7 +309,7 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
         try:
             data = self.set_common_fields(timer, start, end, tags)
         except ValidationError as error:
-            _LOGGER.error(error)
+            LOGGER.error(error)
             return
         if milestone:
             data[ATTR_MILESTONE] = milestone


### PR DESCRIPTION
I saw the thread in #45 

I agree with your comment about adding more sensors and did try this. But given the way the sensors are setup using the `BabyBuddyEntityDescription.key` as the endpoint in the API AND the unique identifier for the sensor, this wasn't possible without quite a major refactor. 

This is my understanding from reading the code for maybe like an hour tops so you I may be completely misunderstanding so sorry if thats the case.

As the issue is quite old and I understand if the project has fallen down your priorities list, I think just doing a replace for now works.

Happy to discuss

Screenshot:
<img width="310" height="97" alt="image" src="https://github.com/user-attachments/assets/b32fee36-94f4-498b-bb3d-1de367803f59" />
<img width="766" height="780" alt="image" src="https://github.com/user-attachments/assets/90655ba0-7626-4c1a-9ea0-7d89bdea34b8" />
<img width="579" height="183" alt="image" src="https://github.com/user-attachments/assets/3f389439-7c2c-441a-9068-d21899cffcf1" />
