### PR TITLE
feat: add support for Baby Buddy medication endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ This integration provides the following entities.
 
 - A sensor for each child, with date of birth returned as state.
 
-- A sensor for each **last** data entry, including `diaper_change`, `feeding`, `notes`, `sleep`, `temperature`, `tummy_time`, `temperature`, and `weight`.
+- A sensor for each **last** data entry, including `diaper_change`, `feeding`, `medication`, `notes`, `sleep`, `temperature`, `tummy_time`, `temperature`, and `weight`.
+
+- The `medication` sensor requires Baby Buddy v2.9.0 or later; on older servers it is simply not created. If a `next_dose_interval` is set on the last entry, the sensor exposes computed `next_dose_time` and `next_dose_ready` attributes.
 
 ### Switches
 
@@ -135,6 +137,21 @@ This service adds a height entry for your child.
 | date                   |   yes    | Specify height recording date (YYYY-MM-DD format, else today() will be used) |
 | notes                  |   yes    | Add notes text to entry                                                      |
 | tags                   |   yes    | Add tag(s) to entry                                                          |
+
+### SERVICE ADD_MEDICATION
+
+This service adds a medication entry for your child. Requires Baby Buddy v2.9.0 or later.
+
+| Service data attribute | Optional | Description                                                                      |
+| ---------------------- | :------: | --------------------------------------------------------------------------------- |
+| entity_id              |    no    | entity_id for the child sensor                                                   |
+| name                   |    no    | Name of the medication administered                                              |
+| dosage                 |   yes    | Specify amount of medication given (float)                                       |
+| dosage_unit            |   yes    | Specify dosage unit. This can be `mg`, `ml`, `tablets`, or `drops`.              |
+| time                   |   yes    | Specify medication time (must be in the past, else now() will be used)           |
+| next_dose_interval     |   yes    | Specify time until the next dose can be given (e.g. `04:00:00`)                  |
+| notes                  |   yes    | Add notes text to entry                                                          |
+| tags                   |   yes    | Add tag(s) to entry                                                              |
 
 ### SERVICE ADD_NOTE
 

--- a/custom_components/babybuddy/const.py
+++ b/custom_components/babybuddy/const.py
@@ -38,6 +38,8 @@ ATTR_CHILDREN: Final[str] = "children"
 ATTR_COLOR: Final[str] = "color"
 ATTR_COUNT: Final[str] = "count"
 ATTR_DESCRIPTIVE: Final[str] = "descriptive"
+ATTR_DOSAGE: Final[str] = "dosage"
+ATTR_DOSAGE_UNIT: Final[str] = "dosage_unit"
 ATTR_DURATION: Final[str] = "duration"
 ATTR_END: Final[str] = "end"
 ATTR_FEEDINGS: Final[str] = "feedings"
@@ -46,9 +48,13 @@ ATTR_HEAD_CIRCUMFERENCE_DASH: Final[str] = "head-circumference"
 ATTR_HEAD_CIRCUMFERENCE_UNDERSCORE: Final[str] = "head_circumference"
 ATTR_HEIGHT: Final[str] = "height"
 ATTR_LAST_NAME: Final[str] = "last_name"
+ATTR_MEDICATION: Final[str] = "medication"
 ATTR_METHOD: Final[str] = "method"
 ATTR_MILESTONE: Final[str] = "milestone"
 ATTR_NAP: Final[str] = "nap"
+ATTR_NEXT_DOSE_INTERVAL: Final[str] = "next_dose_interval"
+ATTR_NEXT_DOSE_READY: Final[str] = "next_dose_ready"
+ATTR_NEXT_DOSE_TIME: Final[str] = "next_dose_time"
 ATTR_NOTE: Final[str] = "note"
 ATTR_NOTES: Final[str] = "notes"
 ATTR_PICTURE: Final[str] = "picture"
@@ -71,6 +77,7 @@ ATTR_ICON_BABY: Final[str] = "mdi:baby"
 ATTR_ICON_CHILD_SENSOR: Final[str] = "mdi:baby-face-outline"
 ATTR_ICON_HEAD: Final[str] = "mdi:head-outline"
 ATTR_ICON_HEIGHT: Final[str] = "mdi:human-male-height"
+ATTR_ICON_MEDICATION: Final[str] = "mdi:pill"
 ATTR_ICON_MOTHER_NURSE: Final[str] = "mdi:mother-nurse"
 ATTR_ICON_NOTE: Final[str] = "mdi:note-multiple-outline"
 ATTR_ICON_PAPER_ROLL: Final[str] = "mdi:paper-roll-outline"
@@ -85,6 +92,7 @@ ATTR_ACTION_ADD_DIAPER_CHANGE: Final[str] = "add_diaper_change"
 ATTR_ACTION_ADD_FEEDING: Final[str] = "add_feeding"
 ATTR_ACTION_ADD_HEAD_CIRCUMFERENCE: Final[str] = "add_head_circumference"
 ATTR_ACTION_ADD_HEIGHT: Final[str] = "add_height"
+ATTR_ACTION_ADD_MEDICATION: Final[str] = "add_medication"
 ATTR_ACTION_ADD_NOTE: Final[str] = "add_note"
 ATTR_ACTION_ADD_PUMPING: Final[str] = "add_pumping"
 ATTR_ACTION_ADD_SLEEP: Final[str] = "add_sleep"
@@ -108,6 +116,7 @@ FEEDING_METHODS: Final = [
 ]
 FEEDING_TYPE: Final[str] = "feeding_type"
 FEEDING_TYPES: Final = ["Breast milk", "Formula", "Fortified breast milk", "Solid food"]
+MEDICATION_DOSAGE_UNITS: Final = ["mg", "ml", "tablets", "drops"]
 
 ERROR_CHILD_SENSOR_SELECT: Final = (
     "Babybuddy child sensor should be selected - ignoring"
@@ -151,6 +160,12 @@ SENSOR_TYPES: tuple[BabyBuddyEntityDescription, ...] = (
         key=ATTR_HEIGHT,
         state_class=SensorStateClass.MEASUREMENT,
         state_key=ATTR_HEIGHT,
+    ),
+    BabyBuddyEntityDescription(
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon=ATTR_ICON_MEDICATION,
+        key=ATTR_MEDICATION,
+        state_key=ATTR_TIME,
     ),
     BabyBuddyEntityDescription(
         device_class=SensorDeviceClass.TIMESTAMP,

--- a/custom_components/babybuddy/coordinator.py
+++ b/custom_components/babybuddy/coordinator.py
@@ -149,6 +149,11 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
         for child in children_list[ATTR_RESULTS]:
             child_data.setdefault(child[ATTR_ID], {})
             for endpoint in SENSOR_TYPES:
+                if endpoint.key not in self.client.endpoints:
+                    LOGGER.debug(
+                        f"Endpoint {endpoint.key} is not available on this babybuddy instance. Skipping."
+                    )
+                    continue
                 endpoint_data: dict = {}
                 try:
                     endpoint_data = await self.client.async_get(

--- a/custom_components/babybuddy/entity.py
+++ b/custom_components/babybuddy/entity.py
@@ -8,7 +8,14 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import ATTR_ID, CONF_API_KEY, CONF_HOST, CONF_PATH, CONF_PORT
+from homeassistant.const import (
+    ATTR_ID,
+    ATTR_TIME,
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PATH,
+    CONF_PORT,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -25,6 +32,10 @@ from .const import (
     ATTR_ICON_CHILD_SENSOR,
     ATTR_ICON_TIMER_SAND,
     ATTR_LAST_NAME,
+    ATTR_MEDICATION,
+    ATTR_NEXT_DOSE_INTERVAL,
+    ATTR_NEXT_DOSE_READY,
+    ATTR_NEXT_DOSE_TIME,
     ATTR_PICTURE,
     ATTR_SLUG,
     ATTR_SOLID,
@@ -151,6 +162,17 @@ class BabyBuddyChildDataSensor(BabyBuddySensor):
                     attrs[ATTR_DESCRIPTIVE] = DIAPER_TYPES[1]
                 if wet_and_solid == (True, True):
                     attrs[ATTR_DESCRIPTIVE] = DIAPER_TYPES[2]
+            if self.entity_description.key == ATTR_MEDICATION and attrs.get(
+                ATTR_NEXT_DOSE_INTERVAL
+            ):
+                # next_dose_time/next_dose_ready are model properties not
+                # exposed by the babybuddy API, so compute them here.
+                time = dt_util.parse_datetime(attrs.get(ATTR_TIME) or "")
+                interval = dt_util.parse_duration(attrs[ATTR_NEXT_DOSE_INTERVAL])
+                if time is not None and interval is not None:
+                    next_dose_time = time + interval
+                    attrs[ATTR_NEXT_DOSE_TIME] = next_dose_time
+                    attrs[ATTR_NEXT_DOSE_READY] = dt_util.now() >= next_dose_time
 
         return attrs
 

--- a/custom_components/babybuddy/services.py
+++ b/custom_components/babybuddy/services.py
@@ -28,6 +28,7 @@ from .const import (
     ATTR_ACTION_ADD_FEEDING,
     ATTR_ACTION_ADD_HEAD_CIRCUMFERENCE,
     ATTR_ACTION_ADD_HEIGHT,
+    ATTR_ACTION_ADD_MEDICATION,
     ATTR_ACTION_ADD_NOTE,
     ATTR_ACTION_ADD_PUMPING,
     ATTR_ACTION_ADD_SLEEP,
@@ -42,6 +43,8 @@ from .const import (
     ATTR_CHILD,
     ATTR_CHILDREN,
     ATTR_COLOR,
+    ATTR_DOSAGE,
+    ATTR_DOSAGE_UNIT,
     ATTR_END,
     ATTR_FEEDINGS,
     ATTR_FIRST_NAME,
@@ -49,9 +52,11 @@ from .const import (
     ATTR_HEAD_CIRCUMFERENCE_UNDERSCORE,
     ATTR_HEIGHT,
     ATTR_LAST_NAME,
+    ATTR_MEDICATION,
     ATTR_METHOD,
     ATTR_MILESTONE,
     ATTR_NAP,
+    ATTR_NEXT_DOSE_INTERVAL,
     ATTR_NOTE,
     ATTR_NOTES,
     ATTR_PUMPING,
@@ -71,6 +76,7 @@ from .const import (
     FEEDING_METHODS,
     FEEDING_TYPES,
     LOGGER,
+    MEDICATION_DOSAGE_UNITS,
 )
 from .coordinator import BabyBuddyConfigEntry, BabyBuddyCoordinator
 from .errors import ValidationError
@@ -293,6 +299,30 @@ async def async_add_height(call: ServiceCall) -> None:
     # date_now = dt_util.now().date()
     date_time_now = get_datetime_from_time(dt_util.now())
     await coordinator.client.async_post(ATTR_HEIGHT, data, date_time_now)
+    await coordinator.async_request_refresh()
+
+
+async def async_add_medication(call: ServiceCall) -> None:
+    """Add a medication entry."""
+    coordinator = await __async_extract_entry_coordinator(call)
+    data = await __setup_service_data(call)
+
+    if call.data.get(ATTR_TIME):
+        try:
+            date_time = get_datetime_from_time(call.data.get(ATTR_TIME))
+            data[ATTR_TIME] = date_time
+        except ValidationError as error:
+            LOGGER.error(error)
+            return
+    if call.data.get(ATTR_NEXT_DOSE_INTERVAL):
+        data[ATTR_NEXT_DOSE_INTERVAL] = str(call.data[ATTR_NEXT_DOSE_INTERVAL])
+    if call.data.get(ATTR_NOTES):
+        data[ATTR_NOTES] = call.data.get(ATTR_NOTES)
+    if call.data.get(ATTR_TAGS):
+        data[ATTR_TAGS] = call.data.get(ATTR_TAGS)
+
+    date_time_now = get_datetime_from_time(dt_util.now())
+    await coordinator.client.async_post(ATTR_MEDICATION, data, date_time_now)
     await coordinator.async_request_refresh()
 
 
@@ -540,6 +570,21 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 **COMMON_FIELDS,
                 vol.Required(ATTR_HEIGHT): cv.positive_float,
                 vol.Optional(ATTR_DATE): cv.date,
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        ATTR_ACTION_ADD_MEDICATION,
+        async_add_medication,
+        vol.Schema(
+            {
+                **COMMON_FIELDS,
+                vol.Required(ATTR_NAME): cv.string,
+                vol.Optional(ATTR_DOSAGE): cv.positive_float,
+                vol.Optional(ATTR_DOSAGE_UNIT): vol.In(MEDICATION_DOSAGE_UNITS),
+                vol.Optional(ATTR_TIME): vol.Any(cv.datetime, cv.time),
+                vol.Optional(ATTR_NEXT_DOSE_INTERVAL): cv.time_period,
             }
         ),
     )

--- a/custom_components/babybuddy/services.yaml
+++ b/custom_components/babybuddy/services.yaml
@@ -302,6 +302,73 @@ add_height:
         text:
           multiple: true
 
+add_medication:
+  name: Add medication
+  description: Adds a medication entry
+  fields:
+    child:
+      name: Child
+      required: true
+      selector:
+        entity:
+          integration: babybuddy
+          domain: sensor
+          device_class: babybuddy_child
+    name:
+      name: Medication name
+      description: Name of the medication administered
+      example: Tylenol
+      required: true
+      selector:
+        text:
+    dosage:
+      name: Dosage
+      description: Amount of medication given
+      example: 5.0
+      selector:
+        number:
+          min: 0.1
+          max: 1000.0
+          step: 0.1
+          mode: box
+    dosage_unit:
+      name: Dosage unit
+      description: Unit for the dosage amount
+      example: ml
+      selector:
+        select:
+          options:
+            - mg
+            - ml
+            - tablets
+            - drops
+    time:
+      name: Medication time
+      description: Medication time
+      example: "15:00:00"
+      selector:
+        time:
+    next_dose_interval:
+      name: Next dose interval
+      description: Time until the next dose can be given
+      example: "04:00:00"
+      selector:
+        duration:
+    notes:
+      name: Medication notes
+      description: Medication notes
+      example: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur et blandit elit. Duis in varius eros. Morbi eleifend, nulla a.
+      selector:
+        text:
+          multiline: true
+    tags:
+      name: Tag(s)
+      description: Tag(s) to apply
+      example: '["Tag 1", "Tag 2", "Tag 3"]'
+      selector:
+        text:
+          multiple: true
+
 add_note:
   name: Add note
   description: Adds a note entry

--- a/tests/const.py
+++ b/tests/const.py
@@ -10,6 +10,8 @@ from custom_components.babybuddy.const import (
     ATTR_BIRTH_DATE,
     ATTR_BMI,
     ATTR_COLOR,
+    ATTR_DOSAGE,
+    ATTR_DOSAGE_UNIT,
     ATTR_END,
     ATTR_FIRST_NAME,
     ATTR_HEAD_CIRCUMFERENCE_UNDERSCORE,
@@ -18,6 +20,7 @@ from custom_components.babybuddy.const import (
     ATTR_METHOD,
     ATTR_MILESTONE,
     ATTR_NAP,
+    ATTR_NEXT_DOSE_INTERVAL,
     ATTR_NOTE,
     ATTR_NOTES,
     ATTR_START,
@@ -33,6 +36,7 @@ from custom_components.babybuddy.const import (
 )
 from homeassistant.const import (
     ATTR_DATE,
+    ATTR_NAME,
     ATTR_TEMPERATURE,
     ATTR_TIME,
     CONF_API_KEY,
@@ -109,6 +113,15 @@ MOCK_SERVICE_ADD_HEAD_CIRCUMFERENCE = {
 MOCK_SERVICE_ADD_HEIGHT = {
     ATTR_HEIGHT: MOCK_NUMBER,
     ATTR_DATE: MOCK_DATE_NOW,
+    ATTR_NOTES: MOCK_TEXT,
+    ATTR_TAGS: [MOCK_TEXT],
+}
+MOCK_SERVICE_ADD_MEDICATION = {
+    ATTR_NAME: "Test Medication",
+    ATTR_DOSAGE: MOCK_NUMBER,
+    ATTR_DOSAGE_UNIT: "ml",
+    ATTR_TIME: MOCK_DATETIME_NOW,
+    ATTR_NEXT_DOSE_INTERVAL: timedelta(hours=4),
     ATTR_NOTES: MOCK_TEXT,
     ATTR_TAGS: [MOCK_TEXT],
 }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,19 +7,26 @@ from custom_components.babybuddy.const import (
     ATTR_ACTION_ADD_DIAPER_CHANGE,
     ATTR_ACTION_ADD_HEAD_CIRCUMFERENCE,
     ATTR_ACTION_ADD_HEIGHT,
+    ATTR_ACTION_ADD_MEDICATION,
     ATTR_ACTION_ADD_NOTE,
     ATTR_ACTION_ADD_TEMPERATURE,
     ATTR_ACTION_ADD_WEIGHT,
     ATTR_BMI,
     ATTR_CHILD,
+    ATTR_DOSAGE,
+    ATTR_DOSAGE_UNIT,
     ATTR_HEAD_CIRCUMFERENCE_UNDERSCORE,
     ATTR_HEIGHT,
     ATTR_ICON_HEAD,
     ATTR_ICON_HEIGHT,
+    ATTR_ICON_MEDICATION,
     ATTR_ICON_NOTE,
     ATTR_ICON_PAPER_ROLL,
     ATTR_ICON_SCALE,
     ATTR_ICON_THERMOMETER,
+    ATTR_NEXT_DOSE_INTERVAL,
+    ATTR_NEXT_DOSE_READY,
+    ATTR_NEXT_DOSE_TIME,
     ATTR_NOTE,
     ATTR_NOTES,
     ATTR_TAGS,
@@ -35,6 +42,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_ICON,
+    ATTR_NAME,
     ATTR_TEMPERATURE,
     ATTR_TIME,
 )
@@ -48,6 +56,7 @@ from .const import (
     MOCK_SERVICE_ADD_DIAPER_CHANGE,
     MOCK_SERVICE_ADD_HEAD_CIRCUMFERENCE,
     MOCK_SERVICE_ADD_HEIGHT,
+    MOCK_SERVICE_ADD_MEDICATION,
     MOCK_SERVICE_ADD_NOTE,
     MOCK_SERVICE_ADD_TEMPERATURE,
     MOCK_SERVICE_ADD_WEIGHT,
@@ -174,6 +183,42 @@ async def test_service_add_height(
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
     assert state.attributes[ATTR_TAGS] == MOCK_SERVICE_ADD_HEIGHT[ATTR_TAGS]
     assert state.state == str(MOCK_SERVICE_ADD_HEIGHT[ATTR_HEIGHT])
+
+
+@pytest.mark.usefixtures("setup_baby_buddy_entry_live")
+async def test_service_add_medication(
+    hass: HomeAssistant,
+) -> None:
+    """Test the "add medication" service call."""
+
+    baby_entity_id = MOCK_BABY_SENSOR_ID
+    entity_id = f"sensor.{MOCK_BABY_NAME}_last_medication"
+    await hass.services.async_call(
+        DOMAIN,
+        ATTR_ACTION_ADD_MEDICATION,
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_MEDICATION},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
+    assert state.attributes[ATTR_ICON] == ATTR_ICON_MEDICATION
+    assert state.attributes[ATTR_NAME] == MOCK_SERVICE_ADD_MEDICATION[ATTR_NAME]
+    assert state.attributes[ATTR_DOSAGE] == MOCK_SERVICE_ADD_MEDICATION[ATTR_DOSAGE]
+    assert (
+        state.attributes[ATTR_DOSAGE_UNIT]
+        == MOCK_SERVICE_ADD_MEDICATION[ATTR_DOSAGE_UNIT]
+    )
+    assert state.attributes[ATTR_NOTES] == MOCK_SERVICE_ADD_MEDICATION[ATTR_NOTES]
+    assert state.attributes[ATTR_TAGS] == MOCK_SERVICE_ADD_MEDICATION[ATTR_TAGS]
+    assert (
+        state.attributes[ATTR_NEXT_DOSE_TIME]
+        == MOCK_SERVICE_ADD_MEDICATION[ATTR_TIME]
+        + MOCK_SERVICE_ADD_MEDICATION[ATTR_NEXT_DOSE_INTERVAL]
+    )
+    assert state.attributes[ATTR_NEXT_DOSE_READY] is True
+    assert dt_util.parse_datetime(state.state) == MOCK_SERVICE_ADD_MEDICATION[ATTR_TIME]
 
 
 @pytest.mark.usefixtures("setup_baby_buddy_entry_live")


### PR DESCRIPTION
## Summary

Baby Buddy [v2.9.0](https://github.com/babybuddy/babybuddy/releases/tag/v2.9.0) added medication tracking ([babybuddy/babybuddy#1036](https://github.com/babybuddy/babybuddy/pull/1036)) with full CRUD at `/api/medication/`. This PR adds support for it to the integration.

Closes #173

## Changes

- **New per-child sensor** `sensor.<child>_last_medication` — timestamp state (same pattern as the changes/notes sensors), `mdi:pill` icon. The full API record (`name`, `dosage`, `dosage_unit`, `time`, `next_dose_interval`, `notes`, `tags`) is exposed as attributes.
- **Computed `next_dose_time` / `next_dose_ready` attributes** — Baby Buddy defines these as server-side model properties but does not expose them via the API, so the sensor computes them from `time + next_dose_interval` when an interval is set (enables next-dose reminder automations without templates).
- **New `babybuddy.add_medication` service** — required `name`; optional `dosage`, `dosage_unit` (`mg`/`ml`/`tablets`/`drops`), `time`, `next_dose_interval` (duration), `notes`, `tags`. Modeled on `add_temperature`.
- **Coordinator guard for older servers** — the update loop now skips `SENSOR_TYPES` keys missing from the discovered `/api/` root. Without this, any endpoint absent from the server (e.g. `medication` on Baby Buddy < 2.9.0) raises an uncaught `KeyError` on every refresh, since `BabyBuddyClient.async_get` indexes `self.endpoints` directly. With the guard, pre-2.9.0 servers keep working and simply don't get the sensor.
- `delete_last_entry` works with the new sensor unchanged (the endpoint key parsed from the entity_id, `medication`, matches the API root key exactly).
- Tests (`MOCK_SERVICE_ADD_MEDICATION`, `test_service_add_medication`) and README documentation, including the v2.9.0 requirement.

## Testing

Verified end-to-end against a live `lscr.io/linuxserver/babybuddy:latest` (2.9.x) container:

- `add_medication` POSTs correctly (the `next_dose_interval` timedelta serializes to `"04:00:00"`, accepted by Django's `parse_duration`), returns 201, and the record round-trips with all fields intact.
- The sensor is created with timestamp state and all attributes, including the computed `next_dose_time`/`next_dose_ready`.
- `delete_last_entry` targeting the medication sensor issues `DELETE /api/medication/<id>/` successfully.
- On a server without the endpoint, updates continue with only a debug log (no sensor created).
- `ruff check` / `ruff format` clean on the touched files.

Note: the new pytest test follows the existing `test_service_add_*` pattern, which currently fails suite-wide against recent HA for reasons unrelated to this PR — see #175. The end-to-end verification above was done with a direct service call passing `child:` in the service data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)