### PR TITLE
fix: repair test suite and CI against current Home Assistant

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -61,7 +61,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          # Keep in sync with the Python versions supported by Home Assistant;
+          # '3.x' resolves to 3.14, which homeassistant does not support yet.
+          python-version: '3.13'
           cache: pip
 
       - name: Install requirements

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -55,6 +55,21 @@ jobs:
           # Set API key in GitHub environment
           echo "api_key=$api_key" >> $GITHUB_ENV
 
+      - name: Seed a placeholder child
+        run: |
+          # A freshly started babybuddy container has no children, so the
+          # coordinator's first refresh fails with "No children found" and
+          # the config entry never reaches LOADED (tests/test_config_flow.py
+          # asserts this). The test suite creates its own "lorem"/"ipsum"
+          # child later via the add_child service; this one only exists to
+          # satisfy that first check.
+          curl -sf 'http://localhost:8000/api/children/' \
+            -H "Authorization: Token $api_key" \
+            -H 'Content-Type: application/json' \
+            -d "{\"first_name\":\"ci\",\"last_name\":\"placeholder\",\"birth_date\":\"$(date -I)\"}"
+        env:
+          api_key: ${{ env.api_key }}
+
       - name: Checkout the repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -69,7 +69,13 @@ jobs:
 
       - name: Run tests
         env:
-          BABY_BUDDY_HOST: http://localhost
+          # aiohttp's AsyncResolver (aiodns/pycares) binds its resolver
+          # channel to the event loop active when it's first constructed;
+          # on Python 3.14 that loop doesn't match pytest-asyncio's
+          # per-test loop, so resolving "localhost" raises "Future
+          # attached to a different loop". A loopback IP skips DNS
+          # resolution entirely and avoids it.
+          BABY_BUDDY_HOST: http://127.0.0.1
           BABY_BUDDY_PORT: 8000
           API_KEY: ${{ env.api_key }}
         run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -84,12 +84,6 @@ jobs:
 
       - name: Run tests
         env:
-          # aiohttp's AsyncResolver (aiodns/pycares) binds its resolver
-          # channel to the event loop active when it's first constructed;
-          # on Python 3.14 that loop doesn't match pytest-asyncio's
-          # per-test loop, so resolving "localhost" raises "Future
-          # attached to a different loop". A loopback IP skips DNS
-          # resolution entirely and avoids it.
           BABY_BUDDY_HOST: http://127.0.0.1
           BABY_BUDDY_PORT: 8000
           API_KEY: ${{ env.api_key }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -61,9 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # Keep in sync with the Python versions supported by Home Assistant;
-          # '3.x' resolves to 3.14, which homeassistant does not support yet.
-          python-version: '3.13'
+          python-version: '3.x'
           cache: pip
 
       - name: Install requirements

--- a/custom_components/babybuddy/coordinator.py
+++ b/custom_components/babybuddy/coordinator.py
@@ -168,9 +168,10 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
         return (children_list[ATTR_RESULTS], child_data)
 
 
-async def options_updated_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def options_updated_listener(
+    hass: HomeAssistant, entry: BabyBuddyConfigEntry
+) -> None:
     """Handle options update."""
-    hass.data[DOMAIN][entry.entry_id].update_interval = timedelta(
-        seconds=entry.options[CONF_SCAN_INTERVAL]
-    )
-    await hass.data[DOMAIN][entry.entry_id].async_request_refresh()
+    coordinator = entry.runtime_data.coordinator
+    coordinator.update_interval = timedelta(seconds=entry.options[CONF_SCAN_INTERVAL])
+    await coordinator.async_request_refresh()

--- a/custom_components/babybuddy/entity.py
+++ b/custom_components/babybuddy/entity.py
@@ -14,10 +14,12 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
+from .client import get_datetime_from_time
 from .const import (
     ATTR_BABYBUDDY_CHILD,
     ATTR_BIRTH_DATE,
     ATTR_CHANGES,
+    ATTR_CHILD,
     ATTR_DESCRIPTIVE,
     ATTR_FIRST_NAME,
     ATTR_ICON_CHILD_SENSOR,
@@ -26,6 +28,7 @@ from .const import (
     ATTR_PICTURE,
     ATTR_SLUG,
     ATTR_SOLID,
+    ATTR_START,
     ATTR_TIMER,
     ATTR_TIMERS,
     ATTR_WET,
@@ -203,7 +206,12 @@ class BabyBuddyChildTimerSwitch(CoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start a new timer."""
-        await self.async_start_timer()
+        data: dict[str, Any] = {
+            ATTR_CHILD: self.child[ATTR_ID],
+            ATTR_START: get_datetime_from_time(dt_util.now()),
+        }
+        await self.coordinator.client.async_post(ATTR_TIMERS, data)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Delete active timer."""

--- a/custom_components/babybuddy/entity.py
+++ b/custom_components/babybuddy/entity.py
@@ -63,7 +63,10 @@ class BabyBuddyChildSensor(BabyBuddySensor):
         """Initialize the sensor."""
         super().__init__(coordinator, child)
 
-        self._attr_name = f"Baby {child['first_name']} {child['last_name']}"
+        # HA prefixes the device (child) name, registering the sensor as
+        # sensor.<first>_<last>_baby.
+        self._attr_has_entity_name = True
+        self._attr_name = "Baby"
         self._attr_unique_id = (
             f"{coordinator.entry.data[CONF_API_KEY]}-{child[ATTR_ID]}"
         )

--- a/custom_components/babybuddy/services.py
+++ b/custom_components/babybuddy/services.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 
 from .client import get_datetime_from_time
 from .const import (
@@ -120,9 +120,29 @@ async def __async_extract_entry_coordinator(call: ServiceCall) -> BabyBuddyCoord
     return coordinator
 
 
-async def __setup_service_data(
-    call: ServiceCall, coordinator: BabyBuddyCoordinator
-) -> dict[str, Any]:
+def _resolve_child_id(hass: HomeAssistant, entity_id: str) -> int:
+    """Resolve a babybuddy child id from an entity's registry entry.
+
+    The child id is the segment after the api key in the unique_id
+    ("{api_key}-{child_id}" for the child sensor,
+    "{api_key}-{child_id}-timer" for the timer switch,
+    "{api_key}-{child_id}-{endpoint}" for the data sensors); the api key
+    is a hyphen-free token, so index [1] holds the id in all cases.
+    """
+    entity_entry = er.async_get(hass).async_get(entity_id)
+    if entity_entry is not None:
+        try:
+            return int(entity_entry.unique_id.split("-")[1])
+        except (IndexError, ValueError):
+            pass
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="child_not_found",
+        translation_placeholders={"entity_id": entity_id},
+    )
+
+
+async def __setup_service_data(call: ServiceCall) -> dict[str, Any]:
     """Extract data with child ID from a service call."""
     data = call.data.copy()
 
@@ -134,43 +154,10 @@ async def __setup_service_data(
         # Resolve the child id from the entity registry rather than
         # reconstructing the entity_id from the child's name. Entity ids are
         # sticky in the registry, so a name-derived slug can drift from the
-        # real id (e.g. the child sensor is registered device-prefixed as
-        # sensor.austin_bond_baby_austin_bond, not sensor.baby_austin_bond).
-        # The child id is the segment after the api key in the unique_id
-        # ("{api_key}-{child_id}" for the child sensor,
-        # "{api_key}-{child_id}-timer" for the timer switch); the api key is
-        # a hyphen-free token, so index [1] holds the id in both cases.
-        entity_entry = er.async_get(call.hass).async_get(data[ATTR_CHILD])
-        if entity_entry is None:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="entry_not_loaded",
-            )
-        data[ATTR_CHILD] = int(entity_entry.unique_id.split("-")[1])
-
-    if call.data.get(ATTR_ENTITY_ID):
-        data[ATTR_CHILD] = [
-            child[ATTR_ID]
-            for child in coordinator.data[0]
-            if (
-                child["first_name"].lower()
-                == call.data[ATTR_ENTITY_ID].split(".")[1].split("_")[0]
-                and child["last_name"].lower()
-                == call.data[ATTR_ENTITY_ID].split(".")[1].split("_")[1]
-            )
-        ][0]
-
-    if not data.get(ATTR_CHILD):
-        data[ATTR_CHILD] = [
-            child[ATTR_ID]
-            for child in coordinator.data[0]
-            if (
-                f"sensor.{slugify(f'Baby {child["first_name"]} {child["last_name"]}')}"
-                == call.data[ATTR_CHILD]
-                or f"switch.{slugify(f'{child["first_name"]} {child["last_name"]} Timer')}"
-                == call.data[ATTR_CHILD]
-            )
-        ][0]
+        # real id (e.g. the child sensor used to register device-prefixed as
+        # sensor.<first>_<last>_baby_<first>_<last>, not
+        # sensor.baby_<first>_<last>).
+        data[ATTR_CHILD] = _resolve_child_id(call.hass, data[ATTR_CHILD])
 
     return data
 
@@ -217,7 +204,7 @@ async def async_add_child(call: ServiceCall) -> None:
 async def async_add_bmi(call: ServiceCall) -> None:
     """Add BMI entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     # date_now = dt_util.now().date()
     date_time_now = get_datetime_from_time(dt_util.now())
@@ -228,7 +215,7 @@ async def async_add_bmi(call: ServiceCall) -> None:
 async def async_add_diaper_change(call: ServiceCall) -> None:
     """Add diaper change entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_TIME):
         try:
@@ -263,7 +250,7 @@ async def async_add_diaper_change(call: ServiceCall) -> None:
 async def async_add_head_circumference(call: ServiceCall) -> None:
     """Add head circumference entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_DATE):
         data[ATTR_DATE] = call.data.get(ATTR_DATE)
@@ -283,7 +270,7 @@ async def async_add_head_circumference(call: ServiceCall) -> None:
 async def async_add_height(call: ServiceCall) -> None:
     """Add height entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_DATE):
         data[ATTR_DATE] = call.data.get(ATTR_DATE)
@@ -301,7 +288,7 @@ async def async_add_height(call: ServiceCall) -> None:
 async def async_add_note(call: ServiceCall) -> None:
     """Add note entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_TIME):
         try:
@@ -321,7 +308,7 @@ async def async_add_note(call: ServiceCall) -> None:
 async def async_add_temperature(call: ServiceCall) -> None:
     """Add a temperature entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_TIME):
         try:
@@ -343,7 +330,7 @@ async def async_add_temperature(call: ServiceCall) -> None:
 async def async_add_weight(call: ServiceCall) -> None:
     """Add weight entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     if call.data.get(ATTR_DATE):
         data[ATTR_DATE] = call.data.get(ATTR_DATE)
@@ -361,18 +348,30 @@ async def async_add_weight(call: ServiceCall) -> None:
 async def async_delete_last_entry(call: ServiceCall) -> None:
     """Delete last data entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
-    entity = call.hass.states.get(call.data.get(ATTR_ENTITY_ID))
-    key = call.data[ATTR_ENTITY_ID].split(".")[1].split("_")[3]
+    entity_id = call.data[ATTR_ENTITY_ID]
+    entity = call.hass.states.get(entity_id)
+    entity_entry = er.async_get(call.hass).async_get(entity_id)
+    # The API endpoint is the last segment of the data sensor's unique_id
+    # ("{api_key}-{child_id}-{endpoint}"); the endpoint itself may contain
+    # hyphens (e.g. head-circumference), so split at most twice. Deriving it
+    # from the entity_id instead would break on multi-word endpoints and on
+    # renamed entities.
+    parts = entity_entry.unique_id.split("-", 2) if entity_entry else []
+    if entity is None or len(parts) < 3 or parts[2] == ATTR_TIMER:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_delete_target",
+            translation_placeholders={"entity_id": entity_id},
+        )
 
-    await coordinator.client.async_delete(key, entity.attributes.get(ATTR_ID))
+    await coordinator.client.async_delete(parts[2], entity.attributes.get(ATTR_ID))
     await coordinator.async_request_refresh()
 
 
 async def async_start_timer(call: ServiceCall) -> None:
     """Start a new timer for child."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     try:
         data[ATTR_START] = get_datetime_from_time(
@@ -391,7 +390,7 @@ async def async_start_timer(call: ServiceCall) -> None:
 async def async_add_feeding(call: ServiceCall) -> None:
     """Add a feeding entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     try:
         data = await __set_common_fields(coordinator, call, data)
@@ -418,7 +417,7 @@ async def async_add_feeding(call: ServiceCall) -> None:
 async def async_add_pumping(call: ServiceCall) -> None:
     """Add a pumping entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     try:
         data = await __set_common_fields(coordinator, call, data)
@@ -438,7 +437,7 @@ async def async_add_pumping(call: ServiceCall) -> None:
 async def async_add_sleep(call: ServiceCall) -> None:
     """Add a sleep entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     try:
         data = await __set_common_fields(coordinator, call, data)
@@ -458,7 +457,7 @@ async def async_add_sleep(call: ServiceCall) -> None:
 async def async_add_tummy_time(call: ServiceCall) -> None:
     """Add a tummy time entry."""
     coordinator = await __async_extract_entry_coordinator(call)
-    data = await __setup_service_data(call, coordinator)
+    data = await __setup_service_data(call)
 
     try:
         data = await __set_common_fields(coordinator, call, data)

--- a/custom_components/babybuddy/services.py
+++ b/custom_components/babybuddy/services.py
@@ -82,13 +82,20 @@ SERVICE_ADD_CHILD_SCHEMA: vol.Schema = vol.Schema(
         vol.Required(ATTR_LAST_NAME): cv.string,
     }
 )
+# Until v2.9.0 these were entity services, so existing automations target
+# them with `target: entity_id` (which HA merges into the call data) rather
+# than the documented `child` field. Accept both.
+CHILD_TARGET_FIELDS: dict[vol.Optional, Any] = {
+    vol.Optional(ATTR_CHILD): cv.entity_id,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+}
 COMMON_FIELDS: dict[vol.Required | vol.Optional, Any] = {
-    vol.Required(ATTR_CHILD): cv.entity_id,
+    **CHILD_TARGET_FIELDS,
     vol.Optional(ATTR_NOTES): cv.string,
     vol.Optional(ATTR_TAGS): vol.All(cv.ensure_list, [str]),
 }
 COMMON_FIELDS_TIMER: dict[vol.Required | vol.Optional | vol.Exclusive, Any] = {
-    vol.Required(ATTR_CHILD): cv.entity_id,
+    **CHILD_TARGET_FIELDS,
     vol.Exclusive(ATTR_TIMER, group_of_exclusion="timer_or_start"): cv.boolean,
     vol.Exclusive(ATTR_START, group_of_exclusion="timer_or_start"): vol.Any(
         cv.datetime, cv.time
@@ -146,18 +153,22 @@ async def __setup_service_data(call: ServiceCall) -> dict[str, Any]:
     """Extract data with child ID from a service call."""
     data = call.data.copy()
 
-    if (
-        data.get(ATTR_CHILD)
-        and isinstance(data[ATTR_CHILD], str)
-        and data[ATTR_CHILD].startswith(("sensor.", "switch."))
-    ):
-        # Resolve the child id from the entity registry rather than
-        # reconstructing the entity_id from the child's name. Entity ids are
-        # sticky in the registry, so a name-derived slug can drift from the
-        # real id (e.g. the child sensor used to register device-prefixed as
-        # sensor.<first>_<last>_baby_<first>_<last>, not
-        # sensor.baby_<first>_<last>).
-        data[ATTR_CHILD] = _resolve_child_id(call.hass, data[ATTR_CHILD])
+    # entity_id must not reach the babybuddy POST payload
+    entity_ids = data.pop(ATTR_ENTITY_ID, None)
+    target = data.get(ATTR_CHILD) or (entity_ids[0] if entity_ids else None)
+    if not isinstance(target, str) or not target.startswith(("sensor.", "switch.")):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="child_required",
+        )
+
+    # Resolve the child id from the entity registry rather than
+    # reconstructing the entity_id from the child's name. Entity ids are
+    # sticky in the registry, so a name-derived slug can drift from the
+    # real id (e.g. the child sensor used to register device-prefixed as
+    # sensor.<first>_<last>_baby_<first>_<last>, not
+    # sensor.baby_<first>_<last>).
+    data[ATTR_CHILD] = _resolve_child_id(call.hass, target)
 
     return data
 
@@ -538,7 +549,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_add_note,
         vol.Schema(
             {
-                vol.Required(ATTR_CHILD): cv.entity_id,
+                **CHILD_TARGET_FIELDS,
                 vol.Required(ATTR_NOTE): cv.string,
                 vol.Optional(ATTR_TIME): vol.Any(cv.datetime, cv.time),
                 vol.Optional(ATTR_TAGS): vol.All(cv.ensure_list, [str]),
@@ -585,7 +596,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_start_timer,
         vol.Schema(
             {
-                vol.Required(ATTR_CHILD): cv.entity_id,
+                **CHILD_TARGET_FIELDS,
                 vol.Optional(ATTR_START): vol.Any(cv.datetime, cv.time),
                 vol.Optional(ATTR_NAME): cv.string,
             }

--- a/custom_components/babybuddy/services.py
+++ b/custom_components/babybuddy/services.py
@@ -129,30 +129,24 @@ async def __setup_service_data(
     if (
         data.get(ATTR_CHILD)
         and isinstance(data[ATTR_CHILD], str)
-        and data[ATTR_CHILD].startswith("switch.")
+        and data[ATTR_CHILD].startswith(("sensor.", "switch."))
     ):
-        data[ATTR_CHILD] = [
-            child[ATTR_ID]
-            for child in coordinator.data[0]
-            if (
-                f"switch.{slugify(f'{child["first_name"]} {child["last_name"]} Timer')}"
-                == call.data[ATTR_CHILD]
+        # Resolve the child id from the entity registry rather than
+        # reconstructing the entity_id from the child's name. Entity ids are
+        # sticky in the registry, so a name-derived slug can drift from the
+        # real id (e.g. the child sensor is registered device-prefixed as
+        # sensor.austin_bond_baby_austin_bond, not sensor.baby_austin_bond).
+        # The child id is the segment after the api key in the unique_id
+        # ("{api_key}-{child_id}" for the child sensor,
+        # "{api_key}-{child_id}-timer" for the timer switch); the api key is
+        # a hyphen-free token, so index [1] holds the id in both cases.
+        entity_entry = er.async_get(call.hass).async_get(data[ATTR_CHILD])
+        if entity_entry is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="entry_not_loaded",
             )
-        ][0]
-
-    if (
-        data.get(ATTR_CHILD)
-        and isinstance(data[ATTR_CHILD], str)
-        and data[ATTR_CHILD].startswith("sensor.")
-    ):
-        data[ATTR_CHILD] = [
-            child[ATTR_ID]
-            for child in coordinator.data[0]
-            if (
-                f"sensor.{slugify(f'Baby {child["first_name"]} {child["last_name"]}')}"
-                == call.data[ATTR_CHILD]
-            )
-        ][0]
+        data[ATTR_CHILD] = int(entity_entry.unique_id.split("-")[1])
 
     if call.data.get(ATTR_ENTITY_ID):
         data[ATTR_CHILD] = [

--- a/custom_components/babybuddy/services.py
+++ b/custom_components/babybuddy/services.py
@@ -178,36 +178,26 @@ async def __setup_service_data(
             )
         ][0]
 
-    # might have a timer...
-    if data.get(ATTR_TIMER):
-        for child in coordinator.data[0]:
-            if (
-                f"sensor.{slugify(f'Baby {child["first_name"]} {child["last_name"]}')}"
-                == call.data[ATTR_CHILD]
-                or f"switch.{slugify(f'{child["first_name"]} {child["last_name"]} Timer')}"
-                == call.data[ATTR_CHILD]
-            ):
-                # do we actually have a timer?
-                if child.get(ATTR_TIMERS):
-                    data[ATTR_TIMER] = [
-                        child[ATTR_TIMERS]["id"] for child in coordinator.data[0]
-                    ]
-            # if not, let's delete that key
-            else:
-                del data[ATTR_TIMER]
-
     return data
 
 
 async def __set_common_fields(
-    call: ServiceCall, data: dict[str, Any]
+    coordinator: BabyBuddyCoordinator, call: ServiceCall, data: dict[str, Any]
 ) -> dict[str, Any]:
     """Set data common fields."""
 
     if data.get(ATTR_TIMER):
-        if not self.is_on:
+        timer_data = (
+            coordinator.data[1].get(data[ATTR_CHILD], {}).get(ATTR_TIMERS) or {}
+        )
+        # In Babybuddy 2.0 'active' is not in the JSON response, so treat any
+        # returned timer as active, as only active timers are returned.
+        if not timer_data.get("active", len(timer_data) > 0):
             raise ValidationError("Timer not found or stopped. Timer must be active.")
-        data[ATTR_TIMER] = self.extra_state_attributes[ATTR_ID]
+        # babybuddy derives child/start/end from the timer entry
+        data[ATTR_TIMER] = timer_data[ATTR_ID]
+        for key in (ATTR_CHILD, ATTR_START, ATTR_END):
+            data.pop(key, None)
     else:
         data[ATTR_START] = get_datetime_from_time(
             call.data.get(ATTR_START) or dt_util.now()
@@ -410,7 +400,7 @@ async def async_add_feeding(call: ServiceCall) -> None:
     data = await __setup_service_data(call, coordinator)
 
     try:
-        data = await __set_common_fields(call, data)
+        data = await __set_common_fields(coordinator, call, data)
     except ValidationError as error:
         LOGGER.error(error)
         return
@@ -437,7 +427,7 @@ async def async_add_pumping(call: ServiceCall) -> None:
     data = await __setup_service_data(call, coordinator)
 
     try:
-        data = await __set_common_fields(call, data)
+        data = await __set_common_fields(coordinator, call, data)
     except ValidationError as error:
         LOGGER.error(error)
         return
@@ -457,7 +447,7 @@ async def async_add_sleep(call: ServiceCall) -> None:
     data = await __setup_service_data(call, coordinator)
 
     try:
-        data = await __set_common_fields(call, data)
+        data = await __set_common_fields(coordinator, call, data)
     except ValidationError as error:
         LOGGER.error(error)
         return
@@ -477,7 +467,7 @@ async def async_add_tummy_time(call: ServiceCall) -> None:
     data = await __setup_service_data(call, coordinator)
 
     try:
-        data = await __set_common_fields(call, data)
+        data = await __set_common_fields(coordinator, call, data)
     except ValidationError as error:
         LOGGER.error(error)
         return
@@ -602,6 +592,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_start_timer,
         vol.Schema(
             {
+                vol.Required(ATTR_CHILD): cv.entity_id,
                 vol.Optional(ATTR_START): vol.Any(cv.datetime, cv.time),
                 vol.Optional(ATTR_NAME): cv.string,
             }
@@ -614,7 +605,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_add_feeding,
         vol.Schema(
             {
-                **COMMON_FIELDS,
+                **COMMON_FIELDS_TIMER,
                 vol.Required(ATTR_TYPE): vol.In(FEEDING_TYPES),
                 vol.Required(ATTR_METHOD): vol.In(FEEDING_METHODS),
                 vol.Optional(ATTR_AMOUNT): cv.positive_float,
@@ -628,7 +619,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_add_pumping,
         vol.Schema(
             {
-                **COMMON_FIELDS,
+                **COMMON_FIELDS_TIMER,
                 vol.Required(ATTR_AMOUNT): cv.positive_float,
                 vol.Optional(ATTR_NOTES): cv.string,
             }
@@ -640,7 +631,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_add_sleep,
         vol.Schema(
             {
-                **COMMON_FIELDS,
+                **COMMON_FIELDS_TIMER,
                 vol.Optional(ATTR_NAP): cv.boolean,
                 vol.Optional(ATTR_NOTES): cv.string,
             }
@@ -652,7 +643,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         async_add_tummy_time,
         vol.Schema(
             {
-                **COMMON_FIELDS,
+                **COMMON_FIELDS_TIMER,
                 vol.Optional(ATTR_MILESTONE): cv.string,
             }
         ),

--- a/custom_components/babybuddy/services.yaml
+++ b/custom_components/babybuddy/services.yaml
@@ -588,8 +588,9 @@ start_timer:
   name: Start timer
   description: Start a new timer
   fields:
-    switch:
-      name: Switch
+    child:
+      name: Child
+      description: Timer switch of the child to start a timer for
       required: true
       selector:
         entity:

--- a/custom_components/babybuddy/strings.json
+++ b/custom_components/babybuddy/strings.json
@@ -44,6 +44,9 @@
     "entry_not_loaded": {
       "message": "The Baby Buddy integration is not loaded."
     },
+    "child_required": {
+      "message": "The service call must include a child field or target a Baby Buddy entity."
+    },
     "child_not_found": {
       "message": "Could not find a Baby Buddy child for entity {entity_id}. The child field must be a Baby Buddy child sensor or timer switch entity."
     },

--- a/custom_components/babybuddy/strings.json
+++ b/custom_components/babybuddy/strings.json
@@ -39,5 +39,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_loaded": {
+      "message": "The Baby Buddy integration is not loaded."
+    },
+    "child_not_found": {
+      "message": "Could not find a Baby Buddy child for entity {entity_id}. The child field must be a Baby Buddy child sensor or timer switch entity."
+    },
+    "invalid_delete_target": {
+      "message": "Entity {entity_id} is not a Baby Buddy data sensor with an entry to delete."
+    }
   }
 }

--- a/custom_components/babybuddy/translations/en.json
+++ b/custom_components/babybuddy/translations/en.json
@@ -44,6 +44,9 @@
     "entry_not_loaded": {
       "message": "The Baby Buddy integration is not loaded."
     },
+    "child_required": {
+      "message": "The service call must include a child field or target a Baby Buddy entity."
+    },
     "child_not_found": {
       "message": "Could not find a Baby Buddy child for entity {entity_id}. The child field must be a Baby Buddy child sensor or timer switch entity."
     },

--- a/custom_components/babybuddy/translations/en.json
+++ b/custom_components/babybuddy/translations/en.json
@@ -39,5 +39,16 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "entry_not_loaded": {
+      "message": "The Baby Buddy integration is not loaded."
+    },
+    "child_not_found": {
+      "message": "Could not find a Baby Buddy child for entity {entity_id}. The child field must be a Baby Buddy child sensor or timer switch entity."
+    },
+    "invalid_delete_target": {
+      "message": "Entity {entity_id} is not a Baby Buddy data sensor with an entry to delete."
+    }
   }
 }

--- a/tests/const.py
+++ b/tests/const.py
@@ -194,7 +194,7 @@ MOCK_SERVICE_ADD_TUMMY_TIME_TIMER = {
 }
 
 MOCK_BABY_NAME = f"{MOCK_SERVICE_ADD_CHILD_SCHEMA[ATTR_FIRST_NAME]}_{MOCK_SERVICE_ADD_CHILD_SCHEMA[ATTR_LAST_NAME]}"
-# The child sensor belongs to the child's device, so HA registers it with the
-# device name prefixed: sensor.<first_last>_baby_<first_last>.
-MOCK_BABY_SENSOR_ID = f"sensor.{MOCK_BABY_NAME}_baby_{MOCK_BABY_NAME}"
+# The child sensor belongs to the child's device, so its entity_id starts
+# with the device name: sensor.<first_last>_baby.
+MOCK_BABY_SENSOR_ID = f"sensor.{MOCK_BABY_NAME}_baby"
 MOCK_BABY_SWITCH_ID = f"switch.{MOCK_BABY_NAME}_timer"

--- a/tests/const.py
+++ b/tests/const.py
@@ -194,5 +194,7 @@ MOCK_SERVICE_ADD_TUMMY_TIME_TIMER = {
 }
 
 MOCK_BABY_NAME = f"{MOCK_SERVICE_ADD_CHILD_SCHEMA[ATTR_FIRST_NAME]}_{MOCK_SERVICE_ADD_CHILD_SCHEMA[ATTR_LAST_NAME]}"
-MOCK_BABY_SENSOR_ID = f"sensor.baby_{MOCK_BABY_NAME}"
+# The child sensor belongs to the child's device, so HA registers it with the
+# device name prefixed: sensor.<first_last>_baby_<first_last>.
+MOCK_BABY_SENSOR_ID = f"sensor.{MOCK_BABY_NAME}_baby_{MOCK_BABY_NAME}"
 MOCK_BABY_SWITCH_ID = f"switch.{MOCK_BABY_NAME}_timer"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -33,6 +33,7 @@ from homeassistant.components.sensor.const import (
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_ID,
     ATTR_ICON,
     ATTR_TEMPERATURE,
     ATTR_TIME,
@@ -74,6 +75,26 @@ async def test_service_add_bmi(
     assert state.attributes[ATTR_NOTES] == MOCK_SERVICE_ADD_BMI_SCHEMA[ATTR_NOTES]
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
     assert state.attributes[ATTR_TAGS] == MOCK_SERVICE_ADD_BMI_SCHEMA[ATTR_TAGS]
+    assert state.state == str(MOCK_SERVICE_ADD_BMI_SCHEMA[ATTR_BMI])
+
+
+@pytest.mark.usefixtures("setup_baby_buddy_entry_live")
+async def test_service_add_bmi_entity_id_target(
+    hass: HomeAssistant,
+) -> None:
+    """Test targeting a service with entity_id, as pre-2.9.0 automations do."""
+
+    entity_id = f"sensor.{MOCK_BABY_NAME}_last_bmi"
+    await hass.services.async_call(
+        DOMAIN,
+        ATTR_ACTION_ADD_BMI,
+        MOCK_SERVICE_ADD_BMI_SCHEMA,
+        target={ATTR_ENTITY_ID: MOCK_BABY_SENSOR_ID},
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+
+    assert state
     assert state.state == str(MOCK_SERVICE_ADD_BMI_SCHEMA[ATTR_BMI])
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,6 +11,7 @@ from custom_components.babybuddy.const import (
     ATTR_ACTION_ADD_TEMPERATURE,
     ATTR_ACTION_ADD_WEIGHT,
     ATTR_BMI,
+    ATTR_CHILD,
     ATTR_HEAD_CIRCUMFERENCE_UNDERSCORE,
     ATTR_HEIGHT,
     ATTR_ICON_HEAD,
@@ -32,7 +33,6 @@ from homeassistant.components.sensor.const import (
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
-    ATTR_ENTITY_ID,
     ATTR_ICON,
     ATTR_TEMPERATURE,
     ATTR_TIME,
@@ -64,8 +64,7 @@ async def test_service_add_bmi(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_BMI,
-        MOCK_SERVICE_ADD_BMI_SCHEMA,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_BMI_SCHEMA},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -89,8 +88,7 @@ async def test_service_add_diaper_change(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_DIAPER_CHANGE,
-        MOCK_SERVICE_ADD_DIAPER_CHANGE,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_DIAPER_CHANGE},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -116,8 +114,7 @@ async def test_service_add_head_circumference(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_HEAD_CIRCUMFERENCE,
-        MOCK_SERVICE_ADD_HEAD_CIRCUMFERENCE,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_HEAD_CIRCUMFERENCE},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -145,8 +142,7 @@ async def test_service_add_height(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_HEIGHT,
-        MOCK_SERVICE_ADD_HEIGHT,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_HEIGHT},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -170,8 +166,7 @@ async def test_service_add_note(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_NOTE,
-        MOCK_SERVICE_ADD_NOTE,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_NOTE},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -194,8 +189,7 @@ async def test_service_add_temperature(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_TEMPERATURE,
-        MOCK_SERVICE_ADD_TEMPERATURE,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_TEMPERATURE},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -219,8 +213,7 @@ async def test_service_add_weight(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_WEIGHT,
-        MOCK_SERVICE_ADD_WEIGHT,
-        target={ATTR_ENTITY_ID: baby_entity_id},
+        {ATTR_CHILD: baby_entity_id, **MOCK_SERVICE_ADD_WEIGHT},
         blocking=True,
     )
     state = hass.states.get(entity_id)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,6 +11,7 @@ from custom_components.babybuddy.const import (
     ATTR_ACTION_ADD_SLEEP,
     ATTR_ACTION_ADD_TUMMY_TIME,
     ATTR_AMOUNT,
+    ATTR_CHILD,
     ATTR_DURATION,
     ATTR_ICON_BABY,
     ATTR_ICON_BABY_BOTTLE,
@@ -90,8 +91,7 @@ async def test_service_add_feeding_start_stop(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_FEEDING,
-        MOCK_SERVICE_ADD_FEEDING_START_STOP,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_FEEDING_START_STOP},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -116,8 +116,7 @@ async def test_service_add_feeding_timer(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_FEEDING,
-        MOCK_SERVICE_ADD_FEEDING_TIMER,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_FEEDING_TIMER},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -143,8 +142,7 @@ async def test_service_add_pumping_start_stop(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_PUMPING,
-        MOCK_SERVICE_ADD_PUMPING_START_STOP,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_PUMPING_START_STOP},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -169,8 +167,7 @@ async def test_service_add_pumping_timer(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_PUMPING,
-        MOCK_SERVICE_ADD_PUMPING_TIMER,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_PUMPING_TIMER},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -196,8 +193,7 @@ async def test_service_add_sleep_start_stop(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_SLEEP,
-        MOCK_SERVICE_ADD_SLEEP_START_STOP,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_SLEEP_START_STOP},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -220,8 +216,7 @@ async def test_service_add_sleep_timer(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_SLEEP,
-        MOCK_SERVICE_ADD_SLEEP_TIMER,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_SLEEP_TIMER},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -247,8 +242,7 @@ async def test_service_add_tummy_time_start_stop(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_TUMMY_TIME,
-        MOCK_SERVICE_ADD_TUMMY_TIME_START_STOP,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_TUMMY_TIME_START_STOP},
         blocking=True,
     )
     state = hass.states.get(entity_id)
@@ -276,8 +270,7 @@ async def test_service_add_tummy_time_timer(
     await hass.services.async_call(
         DOMAIN,
         ATTR_ACTION_ADD_TUMMY_TIME,
-        MOCK_SERVICE_ADD_TUMMY_TIME_TIMER,
-        target={ATTR_ENTITY_ID: MOCK_BABY_SWITCH_ID},
+        {ATTR_CHILD: MOCK_BABY_SWITCH_ID, **MOCK_SERVICE_ADD_TUMMY_TIME_TIMER},
         blocking=True,
     )
     state = hass.states.get(entity_id)


### PR DESCRIPTION
Fixes #175.

This makes the pytest suite (and the nightly workflow) green again against current Home Assistant — verified on **Python 3.14 + homeassistant 2026.7.2** (what CI's `python-version: '3.x'` actually resolves to today).

> **Correction from an earlier revision:** this PR briefly pinned CI to Python 3.13 with a claim that HA didn't support 3.14 yet. That was wrong — HA has supported 3.14 since 2026.3. The pin quietly froze the resolved HA at 2026.2.x (the last 3.13-compatible release) instead of fixing anything. The pin is gone; the real breakages on current HA are fixed below.

## 1. Services: resolve the child via the entity registry

`__setup_service_data` resolved the child by reconstructing entity ids from the child's name (e.g. `sensor.{slugify(f'Baby {first} {last}')}`). Current HA prefixes an entity's object_id with the device name when the entity name doesn't already start with it, so the reconstructed id never matches on fresh installs and **every babybuddy service raised `IndexError: list index out of range`**. (Existing installs keep their grandfathered entity ids in the registry, which is why this can go unnoticed.)

All name-derived resolution paths are replaced by a single shared helper that reads the child id off the entity's registry **unique_id** (`{api_key}-{child_id}` for the child sensor, `{api_key}-{child_id}-timer` for the timer switch — the api key is hyphen-free, so the segment after it is the id in both cases). This is stable across HA naming changes and user renames, and unregistered/non-babybuddy targets now raise a translated `ServiceValidationError` (`child_not_found`) instead of `IndexError`.

- **`delete_last_entry`** now derives both its validity check and the API endpoint from the data sensor's unique_id (`{api_key}-{child_id}-{endpoint}`) instead of parsing the entity_id, which broke for multi-word endpoints (`head-circumference`, `tummy-times`) and renamed entities; invalid targets raise a translated `invalid_delete_target`.
- **Child sensor entity_id de-duplication**: the child sensor now uses `has_entity_name` with the name "Baby", so HA composes the name from the device (child) name — new children register as `sensor.<first>_<last>_baby` instead of the doubled `sensor.<first>_<last>_baby_<first>_<last>`. Existing registrations keep their sticky ids and keep working via the registry lookup.
- `strings.json`/`en.json` gain an exceptions section for `child_not_found`, `invalid_delete_target`, and the previously untranslated `entry_not_loaded`.

## 2. Tests: pass `child` in service data instead of `target: entity_id`

Recent HA merges the target's `entity_id` into `call.data` before the registered `vol.Schema` runs, so every service test failed with `extra keys not allowed @ data['entity_id']`. The tests now pass the child/switch entity via the documented `child` field, matching the service contract in `services.yaml`. (The core `switch.turn_on` call in the timer fixture keeps its `target`, since core entity-service schemas allow it.)

## 3. Regressions surfaced by the runnable suite

With the schema failures out of the way, several leftovers from the services/entity refactor showed up; fixed here because the suite can't pass without them:

- **`options_updated_listener`** still read the coordinator from `hass.data[DOMAIN][entry.entry_id]`, which stopped being populated in the `runtime_data` migration — changing options raised `KeyError: 'babybuddy'` in a fire-and-forget task and the new scan interval was never applied. This leaked task is also what killed the config-flow/options tests on CI (surfacing as event-loop errors in teardown). Now uses `entry.runtime_data.coordinator`.
- **`BabyBuddyChildTimerSwitch.async_turn_on`** called `self.async_start_timer()`, which was removed when services moved out of the entity — turning the timer switch on raised `AttributeError`. The timer start is now inlined via the client.
- **Feeding/pumping/sleep/tummy_time schemas** used `COMMON_FIELDS`, so the documented `timer`/`start`/`end` fields were rejected as extra keys; `COMMON_FIELDS_TIMER` existed for exactly this but was unused. Switched.
- **`__set_common_fields`** still referenced `self` from its entity-method days (`NameError` on any `timer: true` call). It now resolves the child's active timer from coordinator data and, like the original entity implementation, submits only the timer id so babybuddy derives child/start/end from the timer entry.
- **`start_timer`** was uncallable: its schema had no child field and `services.yaml` documented the field as `switch`, which the schema rejected. Both now use `child` (the timer switch entity), consistent with the other services.

## Testing

Ran the full suite against a live `lscr.io/linuxserver/babybuddy:latest` container on **Python 3.14** with the current `requirements-test.txt` resolution (**homeassistant 2026.7.2**, pytest-homeassistant-custom-component 0.13.346), same flags as CI (`--verbose --maxfail=1`):

```
20 passed in 92.65s
```

That includes the four timer-based tests end-to-end (switch on → live timer created in babybuddy → entry submitted from the timer → switch back off).

Note: running the suite on Python 3.13 resolves the older HA 2026.2.x, where the child sensor still gets a legacy entity_id — tests asserting the current-HA id will fail there. CI (`'3.x'` → 3.14 → current HA) is the reference environment.

`ruff format` / `ruff check --select I001,I002` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcnWB3thiiJUoaHHJDS9r5