### PR TITLE
Ride through transient network errors in the update coordinator

### DIFF
--- a/custom_components/babybuddy/coordinator.py
+++ b/custom_components/babybuddy/coordinator.py
@@ -43,6 +43,11 @@ from .const import (
 )
 from .errors import AuthorizationError, ConnectError
 
+# Transient network blips (e.g. DNS timeouts) would otherwise mark every
+# entity unavailable for a full poll cycle; keep the previous data for up
+# to this many consecutive failed polls before declaring the update failed.
+MAX_TRANSIENT_FAILURES = 2
+
 SERVICE_ADD_CHILD_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_BIRTH_DATE, default=dt_util.now().date()): cv.date,
@@ -89,6 +94,7 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
         )
         self.device_registry: dr.DeviceRegistry = dr.async_get(self.hass)
         self.child_ids: list[str] = []
+        self._transient_failures: int = 0
 
     async def async_set_children_from_db(self) -> None:
         """Set child_ids from HA database."""
@@ -135,8 +141,22 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
         except ClientResponseError as error:
             if error.status == HTTPStatus.FORBIDDEN:
                 raise ConfigEntryAuthFailed from error
-        except (AsyncIOTimeoutError, ClientError) as error:
             raise UpdateFailed(error) from error
+        except (AsyncIOTimeoutError, ClientError) as error:
+            if (
+                self.data is not None
+                and self._transient_failures < MAX_TRANSIENT_FAILURES
+            ):
+                self._transient_failures += 1
+                LOGGER.debug(
+                    "Error fetching babybuddy data, keeping previous data (%d/%d): %s",
+                    self._transient_failures,
+                    MAX_TRANSIENT_FAILURES,
+                    error,
+                )
+                return self.data
+            raise UpdateFailed(error) from error
+        self._transient_failures = 0
 
         if children_list[ATTR_COUNT] < len(self.child_ids):
             self.child_ids = [child[ATTR_ID] for child in children_list[ATTR_RESULTS]]
@@ -161,6 +181,14 @@ class BabyBuddyCoordinator(DataUpdateCoordinator):
                     continue
                 except (AsyncIOTimeoutError, ClientError) as error:
                     LOGGER.error(error)
+                    # Carry the previous entry forward so the sensor keeps its
+                    # last value instead of raising KeyError on the missing key.
+                    if self.data and endpoint.key in self.data[1].get(
+                        child[ATTR_ID], {}
+                    ):
+                        child_data[child[ATTR_ID]][endpoint.key] = self.data[1][
+                            child[ATTR_ID]
+                        ][endpoint.key]
                     continue
                 data: list[dict[str, str]] = endpoint_data[ATTR_RESULTS]
                 child_data[child[ATTR_ID]][endpoint.key] = data[0] if data else {}


### PR DESCRIPTION
## Problem

A single failed coordinator poll — e.g. a transient DNS timeout (`Cannot connect to host ...: [Timeout while contacting DNS servers]`) — marks **every** entity unavailable for a full scan interval. On networks with an occasionally flaky resolver this causes constant availability flapping (observed: ~90 unavailable blips over 48 hours at the default 60s scan interval, each lasting exactly one poll cycle).

There are also two latent bugs in the same code path:

1. A non-403 `ClientResponseError` on the children fetch is silently swallowed, leaving `children_list = {}` — the update then crashes with `KeyError: 'count'` and an "Unexpected error fetching" traceback instead of a clean `UpdateFailed`.
2. When an individual endpoint fetch fails with a transient error, the endpoint key is dropped from the child's data entirely, so the sensor's `native_value` raises `KeyError` on the next state write.

## Fix

- **Grace window**: on a timeout/`ClientError` during the children fetch, keep returning the previous coordinator data for up to 2 consecutive failed polls (`MAX_TRANSIENT_FAILURES`, logged at debug) before raising `UpdateFailed`. A one-poll blip no longer touches entity availability; a sustained outage still surfaces within ~3 poll cycles.
- Non-403 `ClientResponseError` on the children fetch now raises `UpdateFailed` properly.
- Per-endpoint transient errors carry the previous entry forward instead of dropping the key.

## Testing

Full live suite run against `lscr.io/linuxserver/babybuddy:latest` (21/21 passed, including the flows that exercise the coordinator refresh path). Deployed on a production HA instance exhibiting the DNS flapping — entities now stay available through single-poll resolver blips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcnWB3thiiJUoaHHJDS9r5